### PR TITLE
Put imports inside declaration (outside namespace)

### DIFF
--- a/packages/lib/src/generators/dts-modules.ts
+++ b/packages/lib/src/generators/dts-modules.ts
@@ -95,9 +95,9 @@ export const __version__: string;
       const versionedNamespaceIdentifier = `${name}${node.version.split('.')[0].replace(/[^A-z0-9_]/g, '_')}`;
       const versionedModuleIdentifier = `${moduleIdentifier}?version=${node.version}`;
 
-      const [versionedModuleHeader, versionedModuleSuffix] = [
-        `declare module "${versionedModuleIdentifier}" {
-          namespace ${versionedNamespaceIdentifier} {`,
+      const [versionedModuleDeclaration, versionModuleNamespace, versionedModuleSuffix] = [
+        `declare module "${versionedModuleIdentifier}" {`,
+        `namespace ${versionedNamespaceIdentifier} {`,
         `};
 
         export default ${versionedNamespaceIdentifier};
@@ -110,8 +110,9 @@ export const __version__: string;
       const output = [
         references,
         header,
-        versionedModuleHeader,
+        versionedModuleDeclaration,
         imports,
+        versionModuleNamespace,
         base,
         content,
         suffix,


### PR DESCRIPTION
Otherwise it generates code like this

```ts
/// <reference lib="es2015.iterable" />
/// <reference path="./gobject2.d.ts" />
/// <reference path="./glib2.d.ts" />

/**
 * Gio 2.0
 *
 * Generated from 2.77.0
 */

declare module "gi://Gio?version=2.0" {
    namespace Gio2 {
        import GObject from ["gi://GObject?version=2.0"](gi://GObject?version=2.0);
        import GLib from ["gi://GLib?version=2.0"](gi://GLib?version=2.0);

        export namespace BusType {
            export const $gtype: GObject.GT
```

which throws errors:

```
 Error: Import declarations in a namespace cannot reference a module.ts(1147)
```

Solved by putting imports inside module declaration, but outside of namespace like so

```ts
/// <reference lib="es2015.iterable" />
/// <reference path="./gobject2.d.ts" />
/// <reference path="./glib2.d.ts" />

/**
 * Gio 2.0
 *
 * Generated from 2.77.0
 */

declare module "gi://Gio?version=2.0" {
    import GObject from ["gi://GObject?version=2.0"](gi://GObject?version=2.0);
    import GLib from ["gi://GLib?version=2.0"](gi://GLib?version=2.0);
    
    namespace Gio2 {
        export namespace BusType {
            export const $gtype: GObject.GType<BusType>;
        }
```

relates to #1