### PR TITLE
Export default namespace only in versionless-import

### DIFF
--- a/packages/lib/src/generators/dts-modules.ts
+++ b/packages/lib/src/generators/dts-modules.ts
@@ -104,7 +104,7 @@ export const __version__: string;
       }`
       ];
       const moduleDefinition = `declare module "${moduleIdentifier}" {
-        export * from "${versionedModuleIdentifier}";
+        export { default } from "${versionedModuleIdentifier}";
       }`;
 
       const output = [


### PR DESCRIPTION
When you try to do something like `import Adw from 'gi://Adw'` it fails, saying:

```
Module '"gi://Adw"' has no default export.ts(1192)
```

And this is because of this line in `adw1.d.ts`

```ts
declare module "gi://Adw" {
    export * from "gi://Adw?version=1";
}

```

which can be solved by rewriting it as following:

```ts
declare module "gi://Adw" {
// Notice `export { default }` instead of `export * `
    export { default } from "gi://Adw?version=1";
}
```

this PR combined with #2 closes #1